### PR TITLE
Add flattening delimiter

### DIFF
--- a/lib/grizzled/rails/logger.rb
+++ b/lib/grizzled/rails/logger.rb
@@ -21,6 +21,7 @@ module Grizzled # :nodoc:
           :timeformat            => '%Y/%m/%d %H:%M:%S',
           :colorize              => true,
           :flatten               => true,
+          :flatten_delimiter     => '',
           :flatten_patterns      => [
             /.*/
           ],
@@ -122,7 +123,8 @@ module Grizzled # :nodoc:
               flatten_patterns = ['.*']
             end
             flatten = false
-            flattened_message = message.to_s.gsub("\n", '')
+            flatten_delimiter = options.fetch(:flatten_delimiter, Configuration.flatten_delimiter)
+            flattened_message = message.to_s.gsub("\n", flatten_delimiter)
 
             # Flatten the message if it matches the specified pattern...
             flatten_patterns.each do |pattern|


### PR DESCRIPTION
Hi, that might be useful - in case of multiline syslog issues flattening do the job - if you'll replace newline with delimiter you'll be able to decode newlines while tailing log, eg. via 

``tail -q -n0 -F /var/log/remote/*.log | sed 's/#13/\n/g'``

Backward compatibility was kept.